### PR TITLE
Keyframes animation support

### DIFF
--- a/core/src/main/scala/scalacss/Dsl.scala
+++ b/core/src/main/scala/scalacss/Dsl.scala
@@ -248,6 +248,10 @@ object DslMacros {
       create(None, d, f, classNameSuffix)
   }
 
+  trait MKeyframes {
+    def apply(frames: (Percentage[Int], StyleA)*): Keyframes
+  }
+
   val defaultStyleFClassNameSuffix: (Any, Int) => String =
     (_, index) => (index + 1).toString
 

--- a/core/src/main/scala/scalacss/Macros.scala
+++ b/core/src/main/scala/scalacss/Macros.scala
@@ -44,9 +44,11 @@ object Macros {
     protected def __macroStyle (name: String): MStyle
     protected def __macroStyleF(name: String): MStyleF
     protected def __macroKeyframes(name: String): MKeyframes
+    protected def __macroKeyframeStyle: MStyle
     final protected def style : MStyle  = macro implStyle
     final protected def styleF: MStyleF = macro implStyleF
     final protected def keyframes: MKeyframes  = macro implKeyframes
+    final protected def kstyle : MStyle = __macroKeyframeStyle
   }
 
   // ===================================================================================================================

--- a/core/src/main/scala/scalacss/Macros.scala
+++ b/core/src/main/scala/scalacss/Macros.scala
@@ -38,12 +38,15 @@ object Macros {
 
   def implStyle (c: Context): c.Expr[MStyle]  = impl(c, "__macroStyle")
   def implStyleF(c: Context): c.Expr[MStyleF] = impl(c, "__macroStyleF")
+  def implKeyframes(c: Context): c.Expr[MKeyframes]  = impl(c, "__macroKeyframes")
 
   trait DslMixin {
     protected def __macroStyle (name: String): MStyle
     protected def __macroStyleF(name: String): MStyleF
+    protected def __macroKeyframes(name: String): MKeyframes
     final protected def style : MStyle  = macro implStyle
     final protected def styleF: MStyleF = macro implStyleF
+    final protected def keyframes: MKeyframes  = macro implKeyframes
   }
 
   // ===================================================================================================================

--- a/core/src/main/scala/scalacss/Renderer.scala
+++ b/core/src/main/scala/scalacss/Renderer.scala
@@ -20,7 +20,10 @@ object StringRenderer {
       val sb = new StringBuilder
       val fmt = format(sb)
 
-      val m = Css.mapByMediaQuery(css)                    // Group by MQ
+      val grouped = Css.findStylesAndAnimations(css)
+      grouped._2.foreach(fmt(_))
+
+      val m = Css.mapByMediaQuery(grouped._1)             // Group by MQ
       m.foreach(t => if (t._1.isEmpty)   fmt(None, t._2)) // CSS without MQs first
       m.foreach(t => if (t._1.isDefined) fmt(t._1, t._2)) // CSS with MQs last
       fmt.done()
@@ -46,12 +49,16 @@ object StringRenderer {
   implicit def autoFormatToRenderer(f: Format): Renderer[String] =
     new Default(f)
 
-  case class FormatSB(mqStart : CssMediaQuery                 => Unit,
+  case class FormatSB(kfStart : KeyframeAnimationName         => Unit,
+                      kfsStart: KeyframeAnimationName         => Unit,
+                      mqStart : CssMediaQuery                 => Unit,
                       selStart: (CssMediaQueryO, CssSelector) => Unit,
                       kv1     : (CssMediaQueryO, CssKV)       => Unit,
                       kvn     : (CssMediaQueryO, CssKV)       => Unit,
                       selEnd  : (CssMediaQueryO, CssSelector) => Unit,
                       mqEnd   : CssMediaQuery                 => Unit,
+                      kfsEnd  : KeyframeAnimationName         => Unit,
+                      kfEnd   : KeyframeAnimationName         => Unit,
                       done    : ()                            => Unit) {
 
     def apply(mq: CssMediaQueryO, data: Css.ValuesByMediaQuery): Unit = {
@@ -61,18 +68,30 @@ object StringRenderer {
       mq foreach mqEnd
     }
 
-    def apply(e: CssEntry): Unit = {
-      import e._
-      mq foreach mqStart
-      apply(mq, sel, content)
-      mq foreach mqEnd
-    }
+    def apply(e: CssEntry): Unit = { e match {
+      case e: CssStyleEntry =>
+        e.mq foreach mqStart
+        apply(e.mq, e.sel, e.content)
+        e.mq foreach mqEnd
+      case e: CssKeyframesAnimation =>
+        kfStart(e.name)
+        e.frames foreach { frame =>
+          kfsStart(frame._1.value)
+          frame._2.foreach(e => printCssKV(e.mq, e.content))
+          kfsEnd(frame._1.value)
+        }
+        kfEnd(e.name)
+    }}
 
     def apply(mq: CssMediaQueryO, sel: CssSelector, kvs: NonEmptyVector[CssKV]): Unit = {
       selStart(mq, sel)
+      printCssKV(mq, kvs)
+      selEnd(mq, sel)
+    }
+
+    def printCssKV(mq: CssMediaQueryO, kvs: NonEmptyVector[CssKV]): Unit = {
       kv1(mq, kvs.head)
       kvs.tail.foreach(kvn(mq, _))
-      selEnd(mq, sel)
     }
   }
 
@@ -86,12 +105,16 @@ object StringRenderer {
       sb append c.value
     }
     FormatSB(
+      n      => { sb append s"@keyframes $n{" },
+      s      => { sb append s"$s{" },
       m      => { sb append m; sb append '{' },
       (_, s) => { sb append s; sb append '{' },
       (_, c) => kv(c),
       (_, c) => { sb append ';'; kv (c) },
       (_, _) => sb append '}',
       _      => sb append '}',
+      _      => { sb append '}' },
+      _      => { sb append '}' },
       ()     => ())
   }
 
@@ -112,6 +135,8 @@ object StringRenderer {
         sb append ";\n"
       }
     FormatSB(
+      n => { sb append s"@keyframes $n {\n" },
+      s => { sb append s"$indent$s {\n" },
       mq => {
         sb append mq
         sb append " {\n"
@@ -128,6 +153,8 @@ object StringRenderer {
         if (mq.isEmpty) sb append '\n'
       },
       _ => sb append "}\n\n",
+      _ => { sb append s"$indent}\n\n" },
+      _ => { sb append "}\n\n" },
       () => ())
   }
 

--- a/core/src/main/scala/scalacss/Renderer.scala
+++ b/core/src/main/scala/scalacss/Renderer.scala
@@ -50,14 +50,14 @@ object StringRenderer {
     new Default(f)
 
   case class FormatSB(kfStart : KeyframeAnimationName         => Unit,
-                      kfsStart: KeyframeAnimationName         => Unit,
+                      kfsStart: KeyframeAnimationSelector     => Unit,
                       mqStart : CssMediaQuery                 => Unit,
                       selStart: (CssMediaQueryO, CssSelector) => Unit,
                       kv1     : (CssMediaQueryO, CssKV)       => Unit,
                       kvn     : (CssMediaQueryO, CssKV)       => Unit,
                       selEnd  : (CssMediaQueryO, CssSelector) => Unit,
                       mqEnd   : CssMediaQuery                 => Unit,
-                      kfsEnd  : KeyframeAnimationName         => Unit,
+                      kfsEnd  : KeyframeAnimationSelector     => Unit,
                       kfEnd   : KeyframeAnimationName         => Unit,
                       done    : ()                            => Unit) {
 
@@ -76,9 +76,9 @@ object StringRenderer {
       case e: CssKeyframesAnimation =>
         kfStart(e.name)
         e.frames foreach { frame =>
-          kfsStart(frame._1.value)
+          kfsStart(frame._1)
           frame._2.foreach(e => printCssKV(e.mq, e.content))
-          kfsEnd(frame._1.value)
+          kfsEnd(frame._1)
         }
         kfEnd(e.name)
     }}
@@ -105,8 +105,8 @@ object StringRenderer {
       sb append c.value
     }
     FormatSB(
-      n      => { sb append s"@keyframes $n{" },
-      s      => { sb append s"$s{" },
+      n      => { sb append s"@keyframes ${n.value}{" },
+      s      => { sb append s"${s.value}{" },
       m      => { sb append m; sb append '{' },
       (_, s) => { sb append s; sb append '{' },
       (_, c) => kv(c),
@@ -135,8 +135,8 @@ object StringRenderer {
         sb append ";\n"
       }
     FormatSB(
-      n => { sb append s"@keyframes $n {\n" },
-      s => { sb append s"$indent$s {\n" },
+      n => { sb append s"@keyframes ${n.value} {\n" },
+      s => { sb append s"$indent${s.value} {\n" },
       mq => {
         sb append mq
         sb append " {\n"

--- a/core/src/main/scala/scalacss/Style.scala
+++ b/core/src/main/scala/scalacss/Style.scala
@@ -66,7 +66,7 @@ final case class StyleS(data         : Map[Cond, AVs],
 
   override def toString = inspect
 
-  def inspectCss: Css =
+  def inspectCss: Stream[CssStyleEntry] =
     Css.styleA(StyleA(className getOrElse ClassName("???"), addClassNames, this))(Env.empty)
 
   def inspect: String =

--- a/core/src/main/scala/scalacss/mutable/Register.scala
+++ b/core/src/main/scala/scalacss/mutable/Register.scala
@@ -34,7 +34,7 @@ final class Register(initNameGen: NameGen, macroName: MacroName, errHandler: Err
     s0.addClassNames.nonEmpty && s0.data.isEmpty && s0.className.isEmpty && s0.unsafeExts.isEmpty
 
   private def isTaken(className: ClassName): Boolean =
-    mutex(_styles.exists(_.className === className) || _keyframes.exists(f => f.name == className.value))
+    mutex(_styles.exists(_.className === className) || _keyframes.exists(f => f.name === className))
 
   private def ensureUnique(cn: ClassName): ClassName =
     mutex(

--- a/core/src/main/scala/scalacss/mutable/Register.scala
+++ b/core/src/main/scala/scalacss/mutable/Register.scala
@@ -19,6 +19,7 @@ final class Register(initNameGen: NameGen, macroName: MacroName, errHandler: Err
 
   var _nameGen  = initNameGen
   var _styles   = Vector.empty[StyleA]
+  var _keyframes = Vector.empty[Keyframes]
   var _rendered = false
 
   private def nextName(implicit cnh: ClassNameHint): ClassName =
@@ -33,7 +34,7 @@ final class Register(initNameGen: NameGen, macroName: MacroName, errHandler: Err
     s0.addClassNames.nonEmpty && s0.data.isEmpty && s0.className.isEmpty && s0.unsafeExts.isEmpty
 
   private def isTaken(className: ClassName): Boolean =
-    mutex(_styles.exists(_.className === className))
+    mutex(_styles.exists(_.className === className) || _keyframes.exists(f => f.name == className.value))
 
   private def ensureUnique(cn: ClassName): ClassName =
     mutex(
@@ -59,7 +60,6 @@ final class Register(initNameGen: NameGen, macroName: MacroName, errHandler: Err
     }
 
   def registerS(s0: StyleS)(implicit cnh: ClassNameHint): StyleA = mutex {
-
     val s =
       if (doesntNeedClassName(s0)) {
         val h = s0.addClassNames.head
@@ -130,13 +130,19 @@ final class Register(initNameGen: NameGen, macroName: MacroName, errHandler: Err
     implicit def f[W, I: StyleLookup](implicit h: ClassNameHint): Case.Aux[Named[W, StyleF[I]], Named[W, I => StyleA]] = at(_ map registerF[I])
   }
 
+  def registerKeyframes(keyframes: Keyframes) = {
+    _keyframes :+= keyframes
+  }
+
   def styles: Vector[StyleA] = mutex {
     _rendered = true
     _styles
   }
 
-  def css(implicit env: Env): Css =
-    Css(styles)
+  def css(implicit env: Env): Css = {
+    val keyframes = _keyframes.flatMap(_.frames.map(_._2)).map(_.className)
+    Css.prepareStyles(styles.filter(s => !keyframes.contains(s.className))) ++ Css.prepareKeyframes(_keyframes)
+  }
 
   def render[Out](implicit r: Renderer[Out], env: Env): Out =
     r(css)

--- a/core/src/main/scala/scalacss/mutable/StyleSheet.scala
+++ b/core/src/main/scala/scalacss/mutable/StyleSheet.scala
@@ -134,6 +134,7 @@ object StyleSheet {
 
     override protected def __macroStyle (name: String) = new MStyle (name)
     override protected def __macroStyleF(name: String) = new MStyleF(name)
+    override protected def __macroKeyframes(name: String) = new MKeyframes(name)
 
     protected class MStyle(name: String) extends DslMacros.MStyle {
       override def apply(t: ToStyle*)(implicit c: Compose): StyleA = {
@@ -152,6 +153,14 @@ object StyleSheet {
           case None    => register.registerFM(StyleF(f)(d), name)(classNameSuffix)
           case Some(n) => register.registerF2(StyleF(f)(d), n)(classNameSuffix)
         }
+    }
+
+    protected class MKeyframes(name: String) extends DslMacros.MKeyframes {
+      override def apply(frames: (KeyframeAnimationSelector, StyleA)*): Keyframes = {
+        val k = Keyframes(name, frames)
+        register.registerKeyframes(k)
+        k
+      }
     }
 
     protected def styleC[M <: HList](s: StyleC)(implicit m: Mapper.Aux[register._registerC.type, s.S, M], u: MkUsage[M]): u.Out =

--- a/core/src/main/scala/scalacss/mutable/StyleSheet.scala
+++ b/core/src/main/scala/scalacss/mutable/StyleSheet.scala
@@ -135,6 +135,7 @@ object StyleSheet {
     override protected def __macroStyle (name: String) = new MStyle (name)
     override protected def __macroStyleF(name: String) = new MStyleF(name)
     override protected def __macroKeyframes(name: String) = new MKeyframes(name)
+    override protected def __macroKeyframeStyle = new MKStyle
 
     protected class MStyle(name: String) extends DslMacros.MStyle {
       override def apply(t: ToStyle*)(implicit c: Compose): StyleA = {
@@ -156,11 +157,18 @@ object StyleSheet {
     }
 
     protected class MKeyframes(name: String) extends DslMacros.MKeyframes {
-      override def apply(frames: (KeyframeAnimationSelector, StyleA)*): Keyframes = {
-        val k = Keyframes(name, frames)
-        register.registerKeyframes(k)
-        k
+      override def apply(frames: (KeyframeAnimationSelector, StyleA)*): Keyframes =
+        register.registerKeyframes(Keyframes(ClassName(name), frames))
+    }
+
+    protected class MKStyle extends DslMacros.MStyle {
+      override def apply(t: ToStyle*)(implicit c: Compose): StyleA = {
+        val s = Dsl.style(t: _*)
+        StyleA(ClassName("kstyle"), s.addClassNames, s)
       }
+
+      override def apply(className: String)(t: ToStyle*)(implicit c: Compose): StyleA =
+        apply(t:_*)
     }
 
     protected def styleC[M <: HList](s: StyleC)(implicit m: Mapper.Aux[register._registerC.type, s.S, M], u: MkUsage[M]): u.Out =

--- a/core/src/main/scala/scalacss/package.scala
+++ b/core/src/main/scala/scalacss/package.scala
@@ -47,7 +47,7 @@ package object scalacss {
   /**
     * Keyframes animation in CSS
     */
-  type KeyframeAnimationName = String
+  type KeyframeAnimationName = ClassName
   type KeyframeAnimationSelector = Percentage[Int]
 
   sealed trait CssEntry

--- a/core/src/main/scala/scalacss/package.scala
+++ b/core/src/main/scala/scalacss/package.scala
@@ -81,8 +81,8 @@ package object scalacss {
           A.equalIsNatural
         override def equal(a: CssKeyframesAnimation, b: CssKeyframesAnimation): Boolean =
           A.equal(a.name, b.name) &&
-          a.frames.size == b.frames.size &&
-          a.frames.keys.forall(k => b.frames.contains(k) && streamEqual[CssStyleEntry].equal(a.frames(k), b.frames(k)))
+            streamEqual[String].equal(a.frames.keys.toStream.map(_.value), b.frames.keys.toStream.map(_.value)) &&
+            a.frames.keys.forall(k => streamEqual[CssStyleEntry].equal(a.frames(k), b.frames(k)))
       }
     }
   }
@@ -95,6 +95,7 @@ package object scalacss {
     override def equal(a1: CssEntry, a2: CssEntry): Boolean = { (a1, a2) match {
       case (a: CssStyleEntry, b: CssStyleEntry) => CssStyleEntry.equality.equal(a, b)
       case (a: CssKeyframesAnimation, b: CssKeyframesAnimation) => CssKeyframesAnimation.equality.equal(a, b)
+      case _ => false
     }}})
 
   type WarningMsg = String

--- a/core/src/test/scala/scalacss/full/InlineTest.scala
+++ b/core/src/test/scala/scalacss/full/InlineTest.scala
@@ -153,7 +153,26 @@ object MyInline3 extends StyleSheet.Inline {
     innerObject.andAgain.depth2)
 }
 
-  object InlineTest extends utest.TestSuite {
+object MyInlineWithKeyframes extends StyleSheet.Inline {
+  import dsl._
+
+  val kf1 = keyframes(
+    (0 %%) -> style(
+      height(100 px),
+      width(30 px)
+    ),
+    (20 %%) -> style(
+      height(150 px),
+      width(30 px)
+    ),
+    (100 %%) -> style(
+      height(200 px),
+      width(60 px)
+    )
+  )
+}
+
+object InlineTest extends utest.TestSuite {
   import utest._
   import scalacss.TestUtil._
 
@@ -412,5 +431,25 @@ object MyInline3 extends StyleSheet.Inline {
         assertEq(classNames, List("MyInline-0002", "MyInline-0003", "MyInline-0004"))
       }
     }
+
+    'keyframes - assertEq(norm(MyInlineWithKeyframes.render), norm("""
+       |@keyframes kf1 {
+       |  0% {
+       |  height: 100px;
+       |  width: 30px;
+       |  }
+       |
+       |  20% {
+       |  height: 150px;
+       |  width: 30px;
+       |  }
+       |
+       |  100% {
+       |  height: 200px;
+       |  width: 60px;
+       |  }
+       |
+       |}
+     """.stripMargin))
   }
 }

--- a/core/src/test/scala/scalacss/full/InlineTest.scala
+++ b/core/src/test/scala/scalacss/full/InlineTest.scala
@@ -156,16 +156,18 @@ object MyInline3 extends StyleSheet.Inline {
 object MyInlineWithKeyframes extends StyleSheet.Inline {
   import dsl._
 
+  val s = style(
+    height(100 px),
+    width(30 px)
+  )
+
   val kf1 = keyframes(
-    (0 %%) -> style(
-      height(100 px),
-      width(30 px)
-    ),
-    (20 %%) -> style(
+    (0 %%) -> s,
+    (20 %%) -> kstyle(
       height(150 px),
       width(30 px)
     ),
-    (100 %%) -> style(
+    (100 %%) -> kstyle(
       height(200 px),
       width(60 px)
     )
@@ -433,7 +435,7 @@ object InlineTest extends utest.TestSuite {
     }
 
     'keyframes - assertEq(norm(MyInlineWithKeyframes.render), norm("""
-       |@keyframes kf1 {
+       |@keyframes MyInlineWithKeyframes-kf1 {
        |  0% {
        |  height: 100px;
        |  width: 30px;
@@ -449,6 +451,11 @@ object InlineTest extends utest.TestSuite {
        |  width: 60px;
        |  }
        |
+       |}
+       |
+       |.MyInlineWithKeyframes-s {
+       |  height: 100px;
+       |  width: 30px;
        |}
      """.stripMargin))
   }

--- a/core/src/test/scala/scalacss/mutable/RegisterTest.scala
+++ b/core/src/test/scala/scalacss/mutable/RegisterTest.scala
@@ -37,7 +37,7 @@ object RegisterTest extends TestSuite {
   implicit def env = Env.empty
 
   def stylesToCssMap(s: Vector[StyleA]) =
-    Css(s).map(e => (e.sel, e.content)).toMap
+    Css.prepareStyles(s).map(e => (e.sel, e.content)).toMap
 
   override val tests = TestSuite {
     val reg = new Register(NameGen.numbered(), MacroName.Use, ErrorHandler.noisy)


### PR DESCRIPTION
Example of usage:

```
  val codeAnimation = keyframes(
    (0 %%) -> style(
      backgroundColor.red,
      width(100 %%)
    ),
    (50 %%) -> style(
      backgroundColor.white,
      width(50 %%)
    ),
    (100 %%) -> style(
      backgroundColor.red,
      width(100 %%)
    )
  )

  val code = style(
    border(1 px, solid, black),
    margin(5 px),
    padding(5 px),
    fontFamily := "monospace",
    overflowY.auto,
    animationName := codeAnimation.name,
    animationDuration(5 seconds),
    animationIterationCount := "infinite"
  )
```
