### PR TITLE
Cond composing fix for unsafeExts

### DIFF
--- a/core/src/main/scala/scalacss/Cond.scala
+++ b/core/src/main/scala/scalacss/Cond.scala
@@ -29,7 +29,9 @@ final case class Cond(pseudo: Option[Pseudo], mediaQueries: Vector[Media.Query])
       val newValue = q.get(newCond).fold(av)(_ ++ av)
       q.updated(newCond, newValue)
     }
-    val u = s.unsafeExts.map(e => e.copy(style = applyToStyle(e.style)))
+    val u = s.unsafeExts
+      .map(e => e.copy(style = this.copy(pseudo = None).applyToStyle(e.style)))
+      .map(e => e.copy(cond = this.copy(mediaQueries = Vector.empty) & e.cond))
     s.copy(data = d, unsafeExts = u)
   }
 }

--- a/core/src/main/scala/scalacss/Css.scala
+++ b/core/src/main/scala/scalacss/Css.scala
@@ -51,7 +51,7 @@ object Css {
   }
 
   def unsafeExt(root: CssSelector, u: Style.UnsafeExt)(implicit env: Env): Stream[CssStyleEntry] = {
-    val sel = u.sel(root)
+    val sel = u.sel(s"$root${u.cond}")
     style(sel, u.style)
   }
 

--- a/core/src/main/scala/scalacss/Dsl.scala
+++ b/core/src/main/scala/scalacss/Dsl.scala
@@ -196,7 +196,7 @@ abstract class DslBase
   def media = MediaQueryEmpty
 
   def unsafeExt(f: String => String)(t: ToStyle*)(implicit c: Compose): UnsafeExt =
-    UnsafeExt(f, styleS(t: _*))
+    UnsafeExt(f, Cond.empty, styleS(t: _*))
 
   def unsafeChild(n: String)(t: ToStyle*)(implicit c: Compose): Style.UnsafeExt =
     unsafeExt(_ + " " + n)(t: _*)

--- a/core/src/main/scala/scalacss/Style.scala
+++ b/core/src/main/scala/scalacss/Style.scala
@@ -42,7 +42,7 @@ object Style {
    *
    *            Example: `(_+".debug")` will specify a style only active when a `"debug"` class is present.
    */
-  final case class UnsafeExt(sel: CssSelector => CssSelector, style: StyleS)
+  final case class UnsafeExt(sel: CssSelector => CssSelector, cond: Cond, style: StyleS)
 }
 
 /**

--- a/core/src/test/scala/scalacss/RandomData.scala
+++ b/core/src/test/scala/scalacss/RandomData.scala
@@ -56,7 +56,7 @@ object RandomData {
     }
 
   def unsafeExt(g: Gen[StyleS]): Gen[UnsafeExt] =
-    Gen.apply2(UnsafeExt)(unsafeCssSelEndo, g)
+    Gen.apply3(UnsafeExt)(unsafeCssSelEndo, Gen insert Cond.empty, g)
 
   def unsafeExts(o: Option[Gen[StyleS]]): Gen[UnsafeExts] =
     o.fold[Gen[UnsafeExts]](Gen insert Vector.empty)(g =>

--- a/core/src/test/scala/scalacss/full/InlineTest.scala
+++ b/core/src/test/scala/scalacss/full/InlineTest.scala
@@ -181,6 +181,62 @@ object MyInlineWithFontFace extends StyleSheet.Inline {
   val ff3 = fontFace("myFont3", Seq("local(HelveticaNeue)", "url(font2.woff)"), "expanded", "italic", "200", UnicodeRange(0, 1114111))
 }
 
+object MyInlineComplexCond extends StyleSheet.Inline {
+  import dsl._
+
+  val cond =
+    style("manual")(
+      margin(12 px),
+      padding(0.5 ex),
+
+      &.hover(
+        cursor.zoomIn,
+        media.maxWidth(150 px)(
+          margin(0 px)
+        ),
+
+        unsafeChild(".child")(
+          media.maxWidth(100 px)(
+            margin(2 px)
+          ),
+          margin(5 px)
+        )
+      ),
+
+      unsafeChild(".child2")(
+        &.hover(
+          margin(15 px),
+          media.maxWidth(100 px)(
+            margin(10 px)
+          )
+        )
+      ),
+
+      &.nthChild(5)(
+        cursor.zoomIn,
+        media.maxWidth(150 px)(
+          margin(0 px)
+        ),
+
+        unsafeChild(".row")(
+          media.maxWidth(100 px)(
+            margin(2 px)
+          ),
+          margin(5 px)
+        )
+      ),
+
+      unsafeChild(".row2")(
+        &.nthChild(15)(
+          margin(15 px),
+          media.maxWidth(100 px)(
+            margin(10 px)
+          )
+        )
+      )
+    )
+}
+
 object InlineTest extends utest.TestSuite {
   import utest._
 
@@ -495,5 +551,68 @@ object InlineTest extends utest.TestSuite {
          |  unicode-range: U+0-10ffff;
          |}
        """.stripMargin))
+
+    'complexCond - assertEq(norm(MyInlineComplexCond.render), norm(
+      """.manual:hover {
+        |  cursor: -webkit-zoom-in;
+        |  cursor: -moz-zoom-in;
+        |  cursor: -o-zoom-in;
+        |  cursor: zoom-in;
+        |}
+        |
+        |.manual:nth-child(5) {
+        |  cursor: -webkit-zoom-in;
+        |  cursor: -moz-zoom-in;
+        |  cursor: -o-zoom-in;
+        |  cursor: zoom-in;
+        |}
+        |
+        |.manual {
+        |  margin: 12px;
+        |  padding: 0.5ex;
+        |}
+        |
+        |.manual:hover .child {
+        |  margin: 5px;
+        |}
+        |
+        |.manual .child2:hover {
+        |  margin: 15px;
+        |}
+        |
+        |.manual:nth-child(5) .row {
+        |  margin: 5px;
+        |}
+        |
+        |.manual .row2:nth-child(15) {
+        |  margin: 15px;
+        |}
+        |
+        |@media (max-width:150px) {
+        |  .manual:nth-child(5) {
+        |    margin: 0;
+        |  }
+        |  .manual:hover {
+        |    margin: 0;
+        |  }
+        |}
+        |
+        |@media (max-width:100px) {
+        |  .manual:hover .child {
+        |    margin: 2px;
+        |  }
+        |  .manual .child2:hover {
+        |    margin: 10px;
+        |  }
+        |  .manual:nth-child(5) .row {
+        |    margin: 2px;
+        |  }
+        |  .manual .row2:nth-child(15) {
+        |    margin: 10px;
+        |  }
+        |}
+      """.stripMargin))
   }
 }
+
+


### PR DESCRIPTION
Code:

```
val parent = style(
  ....
  &.hover (
    unsafeChild(".child") (
      ...
    )
  )
)
```

Result:

```
.parent .child:hover {...}
```

Expected:

```
.parent:hover .child {...}
```

Take a look at InlineTest.scala for more complex examples.
